### PR TITLE
Add whoisfam command

### DIFF
--- a/main.py
+++ b/main.py
@@ -231,6 +231,9 @@ async def amifam(ctx):
         await ctx.send('Hmm...that remains to be seen. You have potential. But I\'ll be the judge of that. Check back with me later.')
 
     await update_data(users, ctx.author)
+    with open ('structs/users.json', 'w') as f:
+        json.dump(users, f, indent=2)
+            
     embed = discord.Embed(
         title=f'{ctx.author.display_name}',
         description='How fam are you?',
@@ -291,7 +294,8 @@ async def whoisfam(ctx):
             chan = ctx.guild.get_channel(571507701935374344)
             await chan.send(f'yo...so...I kinda fucked up in {ctx.message.jump_url}\n{err}')
             break
-
+    
+    embed.set_footer(random.choice(memes))    
     await ctx.send(embed=embed)    
 
 @bot.command()

--- a/main.py
+++ b/main.py
@@ -287,8 +287,9 @@ async def whoisfam(ctx):
                 value=fam_by_rank(rank),
                 inline=True
             )
-        except TypeError:
-            await ctx.send("json done fucked up")
+        except TypeError as err:
+            chan = ctx.guild.get_channel(571507701935374344)
+            await chan.send(f'yo...so...I kinda fucked up in {ctx.message.jump_url}\n{err}')
             break
 
     await ctx.send(embed=embed)    

--- a/main.py
+++ b/main.py
@@ -292,7 +292,7 @@ async def whoisfam(ctx):
             )
         except TypeError as err:
             chan = ctx.guild.get_channel(571507701935374344)
-            await chan.send(f'yo...so...I kinda fucked up in {ctx.message.jump_url}\n{err}')
+            await chan.send(f'yo...so...my moves were kinda weak in {ctx.message.jump_url}\n{err}')
             break
     
     embed.set_footer(text=random.choice(memes))    

--- a/main.py
+++ b/main.py
@@ -6,8 +6,8 @@ import discord
 from datetime import datetime as dt
 from discord.ext import commands
 from config.settings import DISCORD_TOKEN
-from structs.responses import *
-from structs.rankings import rank_title
+from structs.responses import memes, err_msg, gottems
+from structs.rankings import fam_by_rank, rank_title
 import progressbar as pb
 from re import search
 
@@ -221,7 +221,7 @@ async def amifam(ctx):
     print(f'{ctx.author} used f.amifam')
 
     with open('structs/users.json', 'r') as f:
-            users = json.load(f)
+        users = json.load(f)
 
     if any(ctx.author.name in js for js in famDict['jsquad']):
         await ctx.send('Fam AND JSquad. Jam, if you will.')
@@ -265,6 +265,33 @@ async def amifam(ctx):
     embed.set_image(url="attachment://expbar.png")
 
     await ctx.send(file=exp_bar, embed=embed)
+
+@bot.command()
+async def whoisfam(ctx):
+    print(f'{ctx.author} used f.whoisfam')
+
+    with open('structs/users.json', 'r') as f:
+        users = json.load(f)
+            
+    await update_data(users, ctx.author)
+    
+    for user_id in users:
+	    if any("1" in rank for rank in users[user_id]["rank"]):
+		    print(users[user_id]["name"])
+    
+    embed = discord.Embed(
+        title='Who Is Fam?',
+        description='The Fam by Rank',
+        color=discord.Color.blue()
+    )
+    for rank in range(10):
+        embed.add_field(
+            name=rank_title[rank].upper(),
+            value=fam_by_rank(rank),
+            inline=True
+        )
+    
+    await ctx.send(embed=embed)    
 
 @bot.command()
 async def time(ctx):

--- a/main.py
+++ b/main.py
@@ -275,22 +275,22 @@ async def whoisfam(ctx):
             
     await update_data(users, ctx.author)
     
-    for user_id in users:
-	    if any("1" in rank for rank in users[user_id]["rank"]):
-		    print(users[user_id]["name"])
-    
     embed = discord.Embed(
         title='Who Is Fam?',
         description='The Fam by Rank',
         color=discord.Color.blue()
     )
-    for rank in range(10):
-        embed.add_field(
-            name=rank_title[rank].upper(),
-            value=fam_by_rank(rank),
-            inline=True
-        )
-    
+    for rank in range(1, 11, 1):
+        try:
+            embed.add_field(
+                name=rank_title[rank].upper(),
+                value=fam_by_rank(rank),
+                inline=True
+            )
+        except TypeError:
+            await ctx.send("json done fucked up")
+            break
+
     await ctx.send(embed=embed)    
 
 @bot.command()

--- a/main.py
+++ b/main.py
@@ -295,7 +295,7 @@ async def whoisfam(ctx):
             await chan.send(f'yo...so...I kinda fucked up in {ctx.message.jump_url}\n{err}')
             break
     
-    embed.set_footer(random.choice(memes))    
+    embed.set_footer(text=random.choice(memes))    
     await ctx.send(embed=embed)    
 
 @bot.command()

--- a/structs/rankings.py
+++ b/structs/rankings.py
@@ -14,17 +14,19 @@ rank_title = {
 }
 
 def fam_by_rank(fam_rank):
-    if isinstance(fam_rank, int):
-        fam_rank = str(fam_rank)
+    # if isinstance(fam_rank, int):
+    #     fam_rank = str(fam_rank)
 
     fam = []
     with open('structs/users.json', 'r') as f:
         users = json.load(f)
 
     for user_id in users:
-        if any(fam_rank in rank for rank in users[user_id]["rank"]):
+        if users[user_id]["rank"] == fam_rank:
             fam.append(users[user_id]["name"])
-    
-    fam_str = "\n".join(fam)
-    
-    return fam_str
+
+    if fam:
+        fam_str = "\n".join(fam)
+        return fam_str
+    else:
+        return "none"

--- a/structs/rankings.py
+++ b/structs/rankings.py
@@ -14,8 +14,6 @@ rank_title = {
 }
 
 def fam_by_rank(fam_rank):
-    # if isinstance(fam_rank, int):
-    #     fam_rank = str(fam_rank)
 
     fam = []
     with open('structs/users.json', 'r') as f:

--- a/structs/rankings.py
+++ b/structs/rankings.py
@@ -1,3 +1,5 @@
+import json
+
 rank_title = {
     1: 'Weak',
     2: 'Step Fam',
@@ -10,3 +12,19 @@ rank_title = {
     9: 'God Fam',
     10: 'OnlyFams'
 }
+
+def fam_by_rank(fam_rank):
+    if isinstance(fam_rank, int):
+        fam_rank = str(fam_rank)
+
+    fam = []
+    with open('structs/users.json', 'r') as f:
+        users = json.load(f)
+
+    for user_id in users:
+        if any(fam_rank in rank for rank in users[user_id]["rank"]):
+            fam.append(users[user_id]["name"])
+    
+    fam_str = "\n".join(fam)
+    
+    return fam_str


### PR DESCRIPTION
# Description
Added `f.whoisfam` command to create an embed that lists all the Fam ranks and the members attributed to those ranks. 

Resolves #12 

# Example
<img width="429" alt="image" src="https://user-images.githubusercontent.com/7218565/142502686-922bd76c-178e-42aa-95a9-6ff21c11b2f8.png">


# Notes
Later iteration may format the embed nicer. 
Includes a few small fixes to other functionality, such as `user.json` updating in `amifam` and exception logging to #modlog channel