### PR TITLE
Scripts docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -354,3 +354,6 @@ MigrationBackup/
 # Environments
 .env
 .venv
+
+# nohup log output
+nohup.out

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip3 install -r requirements.txt
+
+COPY . .
+RUN rm -f .env
+
+CMD ["python3", "main.py"]

--- a/scripts/build-docker
+++ b/scripts/build-docker
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+
+push_flag=""
+rasppi_flag=""
+
+
+print_usage() {
+  printf "Usage:\n  -p push the build as well\n  -r build for the raspberry pi"
+}
+
+
+while getopts 'pr' flag; do
+  case "${flag}" in
+    p) push_flag='true' ;;
+    r) rasppi_flag='true' ;;
+    *) print_usage
+       exit 1 ;;
+  esac
+done
+
+if [[ $rasppi_flag == "true" ]]; then
+    docker buildx build --platform linux/arm/v7 -t wikiwikiwasp/fambot:armv7 .
+else
+    docker build -t wikiwikiwasp/fambot .
+fi
+
+if [[ $push_flag == "true" ]]; then
+    docker push wikiwikiwasp/fambot
+fi

--- a/scripts/start
+++ b/scripts/start
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+nohup_flag=''
+docker_flag=''
+
+print_usage() {
+  printf "Usage:\n  -n to launch with nohup\n  -d to launch with docker\n -dn to run with docker detached"
+}
+
+while getopts 'dn' flag; do
+  case "${flag}" in
+    n) nohup_flag='true' ;;
+    d) docker_flag='true' ;;
+    *) print_usage
+       exit 1 ;;
+  esac
+done
+
+if [[ $docker_flag == "true" ]]; then
+  if [[ $nohup_flag == "true" ]]; then
+    echo running with detached docker
+    docker run -d --env-file ./.env --name=fambot wikiwikiwasp/fambot
+  else 
+    echo running with docker
+    docker run -it --env-file ./.env --name=fambot wikiwikiwasp/fambot
+  fi
+elif [[ $nohup_flag == "true" ]]; then
+  echo running with nohup
+  nohup ./main.py &
+else
+  echo running with python
+  python main.py
+fi

--- a/scripts/start
+++ b/scripts/start
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+
+if [ ! -f .env ]; then
+    echo ".env file not found! please create one and try again"
+    exit 1
+fi
+
+
+
+
 nohup_flag=''
 docker_flag=''
 

--- a/scripts/start
+++ b/scripts/start
@@ -9,31 +9,27 @@ fi
 
 
 
-nohup_flag=''
+detached_flag='-it'
 docker_flag=''
+rasppi_flag=''
 
 print_usage() {
-  printf "Usage:\n  -n to launch with nohup\n  -d to launch with docker\n -dn to run with docker detached"
+  printf "Usage:\n  no options to run with regular python\n  -n to launch with nohup\n  -d to launch with docker\n -dn to run with docker detached\n  -dr to run with the raspberrypi docker image\n  -drn to run the raspberry pi image detached"
 }
 
-while getopts 'dn' flag; do
+while getopts 'dnr' flag; do
   case "${flag}" in
-    n) nohup_flag='true' ;;
+    n) detached_flag='-d' ;;
     d) docker_flag='true' ;;
+    r) rasppi_flag=':armv7' ;;
     *) print_usage
        exit 1 ;;
   esac
 done
 
 if [[ $docker_flag == "true" ]]; then
-  if [[ $nohup_flag == "true" ]]; then
-    echo running with detached docker
-    docker run -d --env-file ./.env --name=fambot wikiwikiwasp/fambot
-  else 
-    echo running with docker
-    docker run -it --env-file ./.env --name=fambot wikiwikiwasp/fambot
-  fi
-elif [[ $nohup_flag == "true" ]]; then
+  docker run $detached_flag --env-file ./.env --name=fambot wikiwikiwasp/fambot$rasppi_flag
+elif [[ $detached_flag == "-it" ]]; then
   echo running with nohup
   nohup ./main.py &
 else

--- a/scripts/stop
+++ b/scripts/stop
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+pid=$(ps -ef | grep -v grep | grep python3 | awk '{ print $2 }')
+
+if [[ $pid == "" ]]; then
+    # There wasn't a nohup pid, check for docker
+    pid=$(docker ps -f name=fambot | grep fambot)
+    
+    if [[ $pid == "" ]]; then
+        # No docker found, echo and exit
+        echo No instance of FamBot found
+        exit 1
+    else
+        # Kill the docker process
+        docker stop fambot
+        docker rm fambot
+    fi
+else
+    # We got the nohup pid from ps
+    kill $pid
+fi


### PR DESCRIPTION
A little bit of a convoluted setup, but I think it should work.  
Resolves #15 
Resolves #16 

# scripts/start
This script has a few options:
- `no options` Running the script with no options at all will just start it with the python command
- `-n` This is the general detached flag. On it's own it starts the app with nohup. On the docker commands, it starts docker detached.
- `-d` The general docker flag. When included, it will launch with docker in some form
- `-r` The raspberry pi flag. When run, it will start the docker container with the armv7 docker image

# scripts/stop
This script takes no options. 
1. It will search for a running python3 process and kill it. This will probably stop nohup if there are no other python3 apps running.  
2. If no python3 process is found, it will search for a docker container named `fambot` and stop + remove it.  
3. If neither of the above are found, it will just spit out a message

# scripts/build-docker
This script will build a docker image at `wikiwikiwasp/fambot`
- `-p` Will cause the script to also push the image built
- `-r` will use buildx to build an armv7 image for raspberry pis

