### PR TITLE
added functionality for logging error messages to an error channel

### DIFF
--- a/cogs/FamRankings.py
+++ b/cogs/FamRankings.py
@@ -228,16 +228,11 @@ class FamRankings(commands.Cog):
             color=discord.Color.blue()
         )
         for rank in range(1, 11, 1):
-            try:
-                embed.add_field(
-                    name=rank_title[rank].upper(),
-                    value=fam_by_rank(rank),
-                    inline=True
-                )
-            except TypeError as err:
-                chan = ctx.guild.get_channel(571507701935374344)
-                await chan.send(f'yo...so...my moves were kinda weak in {ctx.message.jump_url}\n{err}')
-                break
+            embed.add_field(
+                name=rank_title[rank].upper(),
+                value=fam_by_rank(rank),
+                inline=True
+            )
 
         embed.set_footer(text=random.choice(memes))
         await ctx.send(embed=embed)

--- a/config/settings.py
+++ b/config/settings.py
@@ -6,3 +6,4 @@ load_dotenv()
 # Discord
 DISCORD_TOKEN = os.getenv('DISCORD_TOKEN')
 GG_GUILD = os.getenv('GG_GUILD')
+ERROR_CHANNEL = os.getenv('ERROR_CHANNEL')

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ import random
 import os
 import discord
 from discord.ext import commands
-from config.settings import DISCORD_TOKEN
+from config.settings import DISCORD_TOKEN, ERROR_CHANNEL
 from structs.responses import err_msg
 
 client = discord.Client
@@ -22,6 +22,8 @@ async def on_ready():
 async def on_command_error(ctx, error):
     print(f'{ctx.author} tried to use {ctx.message.content}')
     print(error)
+    chan = ctx.guild.get_channel(int(ERROR_CHANNEL))
+    await chan.send(f'yo...so...my moves were kinda weak in {ctx.message.jump_url}\n{error}')
     await ctx.send(random.choice(err_msg))
 
 


### PR DESCRIPTION
I removed the error logging in the WhoIsFam command and put it in the generic command error handler.  
So now all exceptions that get thrown should get logged in the channel.

# This requires a new .env value
In your .env, add `ERROR_CHANNEL=571507701935374344` or something. That's the channel id for #modlog, we we can pick others if we want.