### PR TITLE
changed depreciated reference of "avatar_url" to the v2 "display_avatar"

### DIFF
--- a/cogs/FamRankings.py
+++ b/cogs/FamRankings.py
@@ -235,7 +235,7 @@ class FamRankings(commands.Cog):
             description='How fam are you?',
             color=discord.Color.blue()
         )
-        embed.set_thumbnail(url=ctx.author.avatar_url)
+        embed.set_thumbnail(url=ctx.author.display_avatar)
         if users[f'{ctx.author.id}']['is_fam'] or ctx.author.name in famDict['isfam']:
             embed.add_field(
                 name='FAM?',


### PR DESCRIPTION
# Description
Single line change to replace a deprecated value within the v2 discord.py
This should resolve the error preventing the bot from posting the embed output from the `f.amifam` command

# Example
<img width="376" alt="image" src="https://user-images.githubusercontent.com/7218565/189394896-d6c2170c-f3d4-4b88-b894-e653c061bb4a.png">
(ignore Fambot's responses, Templatebot is the local test bot)
