### PR TITLE
FE3H meme response and lowercase bug fix

### DIFF
--- a/cogs/FamRankings.py
+++ b/cogs/FamRankings.py
@@ -77,12 +77,12 @@ class FamRankings(commands.Cog):
         Args:
             msg (Message): Discord Message object
         """
-        msg.content = msg.content.lower()
+        content = msg.content.lower()
         if msg.author == self.bot.user:
             return
 
         # fam react, but we don't want to react to f.fam
-        if 'fam' in msg.content and not msg.content.startswith(self.bot.command_prefix):
+        if 'fam' in content and not content.startswith(self.bot.command_prefix):
             emoji = discord.utils.get(msg.guild.emojis, name='FAM')
             if emoji:
                 await msg.add_reaction(emoji)

--- a/cogs/KeywordResponder.py
+++ b/cogs/KeywordResponder.py
@@ -35,8 +35,6 @@ class KeywordResponder(commands.Cog):
             msg (Message): Discord Message object
         """
         
-        # 
-        
         if msg.author == self.bot.user:
             return
         
@@ -102,18 +100,6 @@ class KeywordResponder(commands.Cog):
             if random.randint(1, 10) >= 5:
                 await msg.channel.send("get drinked idiot")
             self.start = datetime.today().timestamp()
-            
-        
-
-            #     await msg.channel.send(f'{fe3h[1]} - Emblem')
-            #     await msg.channel.send(f'{fe3h[2]} - Three Houses')
-            # else:
-            #     await msg.channel.send(f'{letter} - Fire')
-            #     await msg.channel.send(f'{letter} - Emblem')
-            #     await msg.channel.send(f'{letter} - Three')
-            #     await msg.channel.send(f'{letter} - Houses')
-            # # await msg.channel.send()
-
         
 async def setup(bot):
 	await bot.add_cog(KeywordResponder(bot))

--- a/cogs/KeywordResponder.py
+++ b/cogs/KeywordResponder.py
@@ -34,36 +34,54 @@ class KeywordResponder(commands.Cog):
         Args:
             msg (Message): Discord Message object
         """
-        msg.content = msg.content.lower()
+        
+        # 
+        
         if msg.author == self.bot.user:
             return
+        
+        # fire emblem three houses
+        fe3h_meme = ['Fire', 'Emblem', 'Three', 'Houses', 'Three Houses']
+        if (search(r"(?:\b[A-Z]{3,4}\b)+", msg.content)) \
+            and random.randint(1, 100) >= 80:
+            fe3h_msg = []
+            fe3h = search(r'(?:\b[A-Z]{3,4}\b)+', msg.content)
+            for x, letter in enumerate(fe3h.group(0)):
+                if len(fe3h.group(0)) == 3 and x == 2:
+                    fe3h_msg.append('{} - {}'.format(letter, fe3h_meme[4]))
+                    break
+                fe3h_msg.append('{} - {}'.format(letter, fe3h_meme[x]))
+            await msg.channel.send("\n".join(fe3h_msg))
+            
+        # lower case message content for remaining keywords
+        content = msg.content.lower()
 
         # hava nice day
-        if (search(' hava ', msg.content) \
-            or msg.content.startswith('hava ') \
-            or msg.content.endswith(' hava') \
-            or msg.content == 'hava') \
-            and not msg.content.startswith("f.") \
+        if (search(' hava ', content) \
+            or content.startswith('hava ') \
+            or content.endswith(' hava') \
+            or content == 'hava') \
+            and not content.startswith("f.") \
             and random.randint(1, 100) >= 90:
             print(f'responding to "hava" from {msg.author}')
             await msg.channel.send('hava nice day fam lmao gottem')
 
         # lmao gottem
-        if 'gottem' in msg.content \
+        if 'gottem' in content \
             and random.randint(1, 100) >= 90:
             print(f'responding to "gottem" from {msg.author}')
             await msg.channel.send(random.choice(gottems))
 
         # butthole
-        if (search('looking for ', msg.content) \
-            or search('where is ', msg.content) \
-            or search('where are ', msg.content)) \
+        if (search('looking for ', content) \
+            or search('where is ', content) \
+            or search('where are ', content)) \
             and random.randint(1, 100) >= 90:
             print(f'responding to "looking for / where is / where are" from {msg.author}')
             await msg.channel.send('https://c.tenor.com/hmwml17QnQ8AAAAC/tom-cardy-butthole.gif')
 
         # suh
-        if (search('suh', msg.content)):
+        if (search('suh', content)):
             print(f'responding to "suh" from {msg.author}')
             await msg.channel.send('https://gfycat.com/adventurousfarazurewingedmagpie')
             
@@ -84,6 +102,18 @@ class KeywordResponder(commands.Cog):
             if random.randint(1, 10) >= 5:
                 await msg.channel.send("get drinked idiot")
             self.start = datetime.today().timestamp()
+            
+        
+
+            #     await msg.channel.send(f'{fe3h[1]} - Emblem')
+            #     await msg.channel.send(f'{fe3h[2]} - Three Houses')
+            # else:
+            #     await msg.channel.send(f'{letter} - Fire')
+            #     await msg.channel.send(f'{letter} - Emblem')
+            #     await msg.channel.send(f'{letter} - Three')
+            #     await msg.channel.send(f'{letter} - Houses')
+            # # await msg.channel.send()
+
         
 async def setup(bot):
 	await bot.add_cog(KeywordResponder(bot))


### PR DESCRIPTION
# Description

Added the feature to have the bot respond with the FE3H meme when a user posts a message with a valid, all caps acronym/word. #48

The conditions for the bot response, to prevent bot spam, are:
- message contains an all caps word/acronym
- between 3-4 characters only
- 20% chance to respond

# Examples:

<img width="363" alt="image" src="https://user-images.githubusercontent.com/7218565/189428890-d9ace5c5-d029-4b37-882b-89e04a195450.png">
<img width="355" alt="image" src="https://user-images.githubusercontent.com/7218565/189428936-73b29351-80cc-482b-9070-1d492ef6bcdb.png">

# Additional

Along with the above, we found a bug that was also fixed. More on that can be found [here](https://github.com/Games-Gamers/FamBot/issues/48#issuecomment-1242375670)