### PR TITLE
Add cooldown and guaranteed post condition to FE3H meme responder

### DIFF
--- a/cogs/KeywordResponder.py
+++ b/cogs/KeywordResponder.py
@@ -24,7 +24,8 @@ drinked_fam = [
 class KeywordResponder(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
-        self.start = datetime.today().timestamp()
+        self.fe3h_cd = datetime.today().timestamp()
+        self.drinked_cd = datetime.today().timestamp()
 
     @commands.Cog.listener()
     async def on_message(self, msg):
@@ -40,17 +41,30 @@ class KeywordResponder(commands.Cog):
         
         # fire emblem three houses
         fe3h_meme = ['Fire', 'Emblem', 'Three', 'Houses', 'Three Houses']
-        if (search(r"(?:\b[A-Z]{3,4}\b)+", msg.content)) \
-            and random.randint(1, 100) >= 80:
-            fe3h_msg = []
+        # regex = all caps word, 3-4 letters
+        if (search(r"(?:\b[A-Z]{3,4}\b)+", msg.content)):
             fe3h = search(r'(?:\b[A-Z]{3,4}\b)+', msg.content)
-            for x, letter in enumerate(fe3h.group(0)):
-                if len(fe3h.group(0)) == 3 and x == 2:
-                    fe3h_msg.append('{} - {}'.format(letter, fe3h_meme[4]))
-                    break
-                fe3h_msg.append('{} - {}'.format(letter, fe3h_meme[x]))
-            await msg.channel.send("\n".join(fe3h_msg))
-            
+            fe3h_msg = []
+            # post every time if immediately followed by a '?'
+            if (search(r'(?:\b[A-Z]{3,4}\?)+', msg.content)):
+                for x, letter in enumerate(fe3h.group(0)):
+                    if len(fe3h.group(0)) == 3 and x == 2:
+                        fe3h_msg.append('{} - {}'.format(letter, fe3h_meme[4]))
+                        break
+                    fe3h_msg.append('{} - {}'.format(letter, fe3h_meme[x]))
+                await msg.channel.send("\n".join(fe3h_msg))
+            # post if 20% chance, 3-4 characters, 2h cooldown
+            elif random.randint(1, 100) >= 80 \
+                and datetime.today().timestamp() - self.fe3h_cd > 7200:
+                for x, letter in enumerate(fe3h.group(0)):
+                    if len(fe3h.group(0)) == 3 and x == 2:
+                        fe3h_msg.append('{} - {}'.format(letter, fe3h_meme[4]))
+                        break
+                    fe3h_msg.append('{} - {}'.format(letter, fe3h_meme[x]))
+                await msg.channel.send("\n".join(fe3h_msg))
+                # restart cooldown
+                self.fe3h_cd = datetime.today().timestamp()
+
         # lower case message content for remaining keywords
         content = msg.content.lower()
 
@@ -93,13 +107,13 @@ class KeywordResponder(commands.Cog):
         # get drinked sticker post
         if msg.author.name in drinked_fam \
             and random.randint(1, 100) >= 90 \
-            and datetime.today().timestamp() - self.start > 21600.0:
+            and datetime.today().timestamp() - self.drinked_cd > 21600.0:
             # posts sticker if its been at least 6 hours since last trigger
             stkr_drinked = self.bot.get_sticker(974028812838895726)
             await msg.channel.send(stickers=[stkr_drinked])
             if random.randint(1, 10) >= 5:
                 await msg.channel.send("get drinked idiot")
-            self.start = datetime.today().timestamp()
+            self.drinked_cd = datetime.today().timestamp()
         
 async def setup(bot):
 	await bot.add_cog(KeywordResponder(bot))


### PR DESCRIPTION
# Description
After feature use by users showed more bot spam than anticipated, I added a 2 hour cooldown (similar to the one #46 used).

Also added a way to guarantee the bot responds with the meme if the acronym/word is immediately followed by a `?`, such as "FETH?".
> Use of the `?` trigger does **not** reset the 2h cooldown.

This should allow for more applicable use of the meme response while also reigning in the bot spam from users attempting to trigger the bot response. 

# Examples

### Guaranteed trigger not resetting cooldown
<img width="409" alt="image" src="https://user-images.githubusercontent.com/7218565/189611722-f932fb97-2b5d-4b2b-9445-ff3071ba83b5.png">


### Normal bot trigger resetting cooldown
<img width="417" alt="image" src="https://user-images.githubusercontent.com/7218565/189611792-d58a6bb7-e3b6-407d-a8bd-4e38e76c02f0.png">

# Notes
Testing the cooldown feature has prompted me to create a new issue (#51) for a dedicated "check cooldown" bot command