### PR TITLE
Bug fixes for VideoLinkEmbeds cog

### DIFF
--- a/cogs/VideoLinkEmbeds.py
+++ b/cogs/VideoLinkEmbeds.py
@@ -4,8 +4,8 @@ import openai
 from config.settings import GPT_TOKEN
 
 model = "gpt-4"
-resp_prompt = f"""
-I have a discord bot, "FamBot", that fixes links shared in the chat. Generate a response that the bot would reply with when posting the fixed link. Use a personality for the bot that's akin to a gamer, internet commenter, and zoomer. Just include the response without quotes. Don't include placeholder for the link like [fixed link].
+resp_prompt = """
+I have a discord bot, "FamBot", that fixes links shared in the chat. Generate a short response that the bot would reply with when posting the fixed link. Use a personality for the bot that's akin to a internet commenter and zoomer. Just include the response without quotes. Don't include placeholder for the link like [fixed link].
 """
 class VideoLinkEmbeds(commands.Cog):
     
@@ -47,10 +47,10 @@ class VideoLinkEmbeds(commands.Cog):
             url = found_url.group()
 
             # detect if embed exists already and has a video element
-            if len(msg.embeds) > 0 and msg.embeds[0].video:
+            if (len(msg.embeds) > 0 and msg.embeds[0].video) \
+                or (len(msg.embeds) > 0 and "twitter.com" in url):
                 return
 
-            
             # gpt generated response
             gpt_response = openai.ChatCompletion.create(
                 model=model,
@@ -73,7 +73,7 @@ class VideoLinkEmbeds(commands.Cog):
                     embed_url = url.replace(base, f"{modification}{base}")
                     await msg.channel.typing()
                     await msg.channel.send(f'{fambot_response}\n{embed_url}')
-                    break # only fix a single link
+                    break # only fix a single link in a single message
 
 async def setup(bot):
     await bot.add_cog(VideoLinkEmbeds(bot))


### PR DESCRIPTION
# Fixes

Updated the AI generated message to be shorter and to drop the "gamer" personality. Should hopefully be only 1-2 sentences and focus on the "zoomer" personality.

Twitter embeds that were just text were triggering the fix link repost, so I added a condition to ignore twitter embeds even without videos. This might need to be readdressed later for the exceptions where a twitter embed is supposed to have a video but it doesn't load it. It will currently skip those instead of fixing them, but at least it will resolve the issue right now where it reposts for no reason.

Also added a change to ignore already modified links so it doesn't add the prefix characters redundantly, breaking the link.

# Still Broken

String case is either being lowered before the content is passed into the cog, somewhere in string manipulation, or during bot message sending. Need to figure out where this is happening, as it's breaking the links that are case-sensitive.